### PR TITLE
Add Helm Chart for multi-service deployment

### DIFF
--- a/Chart/Chart.yaml
+++ b/Chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+name: multi-service
+description: A Helm chart for deploying model-service, app-frontend and app-service to Kubernetes
+version: 0.1.0
+appVersion: "1.0"

--- a/Chart/README.md
+++ b/Chart/README.md
@@ -1,0 +1,75 @@
+# Helm Chart for Multi-Service Deployment
+
+This Helm Chart is designed to deploy a multi-service application, including `model-service`, `app-frontend`, and `app-service`, to a Kubernetes cluster. It allows customization of parameters such as replica counts, container images, and service ports.
+
+## Prerequisites
+
+Before using this Helm Chart, ensure the following prerequisites are met:
+
+1. **Kubernetes Cluster**: A **running** Kubernetes cluster (e.g., Minikube, Kind, or a cloud provider).
+2. **Helm Installed**: Helm CLI installed on your local machine. You can install Helm by following the [official guide](https://helm.sh/docs/intro/install/).
+3. **kubectl Installed**: Ensure `kubectl` is installed and configured to communicate with your Kubernetes cluster.
+
+## Installation
+
+To deploy the services using this Helm Chart, follow these steps:
+
+1. **Clone the Repository**:
+   ```bash
+   git clone <repository-url>
+   cd operation/Chart
+   ```
+
+2. **Install the Chart**:
+   Use the following command to install the Chart. Replace `<release-name>` with a unique name for your deployment:
+   ```bash
+   helm install <release-name> .
+   ```
+
+3. **Verify the Deployment**:
+   After installation, verify that the resources have been created:
+   ```bash
+   kubectl get all -l app=<release-name>
+   ```
+
+## Customization
+
+You can customize the deployment by modifying the `values.yaml` file or by passing parameters directly via the `--set` flag. Below are some examples:
+
+1. **Change the Model Service Port**:
+   ```bash
+   helm install <release-name> . --set modelService.service.port=5020
+   ```
+
+2. **Set Custom Replica Counts**:
+   ```bash
+   helm install <release-name> . --set modelService.replicaCount=2,appFrontend.replicaCount=3
+   ```
+
+3. **Override Container Images**:
+   ```bash
+   helm install <release-name> . --set modelService.image.repository=my-custom-image,modelService.image.tag=v1.0.0
+   ```
+
+## Uninstallation
+
+To uninstall the Chart and delete all associated resources, run:
+```bash
+helm uninstall <release-name>
+```
+
+## Notes
+
+- Ensure that the `values.yaml` file is properly configured for your environment.
+- You can use the `helm template` command to render the templates locally and inspect the generated Kubernetes manifests:
+  ```bash
+  helm template <release-name> .
+  ```
+- Once Chart is modified, run:
+  ```bash
+  helm upgrade <release-name> .
+  ```
+- You can see the rendered Kubernets resource without submitting to the cluster by
+  ```bash
+  elm install <release-name> . --dry-run --debug
+  ```

--- a/Chart/templates/_helpers.tpl
+++ b/Chart/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/*
+Define the chart name.
+*/}}
+{{- define "multi-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Generate a fully qualified name that includes the release name.
+*/}}
+{{- define "multi-service.fullname" -}}
+{{- printf "%s-%s" .Release.Name (include "multi-service.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/Chart/templates/deployment.yaml
+++ b/Chart/templates/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "multi-service.fullname" . }}-model-service
+  labels:
+    app: {{ include "multi-service.name" . }}-model-service
+spec:
+  replicas: {{ .Values.modelService.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "multi-service.name" . }}-model-service
+  template:
+    metadata:
+      labels:
+        app: {{ include "multi-service.name" . }}-model-service
+    spec:
+      containers:
+        - name: model-service
+          image: "{{ .Values.modelService.image.repository }}:{{ .Values.modelService.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.modelService.containerPort }}
+          env:
+            - name: MODEL_URL
+              value: "{{ .Values.modelService.env.modelUrl }}"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "multi-service.fullname" . }}-app-frontend
+  labels:
+    app: {{ include "multi-service.name" . }}-app-frontend
+spec:
+  replicas: {{ .Values.appFrontend.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "multi-service.name" . }}-app-frontend
+  template:
+    metadata:
+      labels:
+        app: {{ include "multi-service.name" . }}-app-frontend
+    spec:
+      containers:
+        - name: app-frontend
+          image: "{{ .Values.appFrontend.image.repository }}:{{ .Values.appFrontend.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.appFrontend.containerPort }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "multi-service.fullname" . }}-app-service
+  labels:
+    app: {{ include "multi-service.name" . }}-app-service
+spec:
+  replicas: {{ .Values.appService.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "multi-service.name" . }}-app-service
+  template:
+    metadata:
+      labels:
+        app: {{ include "multi-service.name" . }}-app-service
+    spec:
+      containers:
+        - name: app-service
+          image: "{{ .Values.appService.image.repository }}:{{ .Values.appService.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.appService.containerPort }}
+          env:
+            - name: MODEL_SERVICE_URL
+              value: "{{ .Values.appService.env.modelServiceUrl }}"

--- a/Chart/values.yaml
+++ b/Chart/values.yaml
@@ -1,0 +1,30 @@
+modelService:
+  replicaCount: 1
+  image:
+    repository: ../../model-service
+    tag: latest
+  containerPort: 5010
+  service:
+    port: 5010
+  env:
+    modelUrl: "https://github.com/remla2025-team16/model-training/releases/download/v1.0.0/sentiment-model.pkl"
+
+appFrontend:
+  replicaCount: 1
+  image:
+    repository: ../../app/app-frontend
+    tag: latest
+  containerPort: 3000
+  service:
+    port: 3000
+
+appService:
+  replicaCount: 1
+  image:
+    repository: ../../app/app-service
+    tag: latest
+  containerPort: 8080
+  service:
+    port: 8080
+  env:
+    modelServiceUrl: "http://model-service:5010"


### PR DESCRIPTION
**Description:**
This pull request introduces a Helm Chart for deploying the multi-service application, which includes model-service, app-frontend, and app-service, to a Kubernetes cluster. The following changes have been made:

- Added Chart.yaml to define the Helm Chart metadata.
- Created values.yaml to allow customization of deployment parameters such as:
    - Replica counts for each service.
    - Container image repositories and tags.
    - Service ports and environment variables.
- Added Kubernetes resource templates in the `templates/` directory:
    - deployment.yaml: Defines the deployment configurations for all three services.
    - _helpers.tpl: Includes helper functions for generating resource names.
- Updated [README.md](http://readme.md/) with instructions for deploying the Helm Chart, verifying the deployment, and customizing parameters.

**Key Features:**

- Supports dynamic configuration of container images and environment variables.
- Allows scaling of replicas for each service.
- Provides a single command to deploy all services to a Kubernetes cluster.

**Next Steps:**

- Ensure the container images specified in values.yaml are accessible from the container registry.
- Deployed the services to a local Kubernetes cluster and confirmed that all pods, services, and deployments are created successfully.