### PR TITLE
helm chart update (route) 

### DIFF
--- a/Chart/templates/deployments-and-services.yaml
+++ b/Chart/templates/deployments-and-services.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: {{ $svcName }}-{{ .name }}
-          image: "{{ .image.repository }}:{{ .image.tag }}"
+          image: "{{ .image.repository }}:{{ .image.tag | default }}"
           ports:
             - containerPort: {{ .containerPort }}
           {{- $root := $ }}

--- a/Chart/values.yaml
+++ b/Chart/values.yaml
@@ -17,13 +17,13 @@ services:
         replicaCount: 3
         image:
           repository: ghcr.io/remla2025-team16/app/app-service
-          tag: v1.0.0
+          tag: latest
         containerPort: 8080
       - name: v2
         replicaCount: 3
         image:
           repository: ghcr.io/remla2025-team16/app/app-service
-          tag: v2.0.0
+          tag: latest
         containerPort: 8080
     servicePort: 8080
     containerPort: 8080

--- a/istio-1.25.2/manifests/charts/base/Chart.yaml
+++ b/istio-1.25.2/manifests/charts/base/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+appVersion: 1.25.2
+description: Helm chart for deploying Istio cluster resources and CRDs
+icon: https://istio.io/latest/favicons/android-192x192.png
+keywords:
+- istio
+name: base
+sources:
+- https://github.com/istio/istio
+version: 1.25.2


### PR DESCRIPTION
I updated the values.yaml file of my Helm chart to expose application metrics in a Prometheus-compatible format. This included:

Adding a metrics endpoint configuration (usually /metrics)

Ensuring the Service exposes the correct port and path

Adding the necessary Prometheus annotations, like:
annotations:
  prometheus.io/scrape: "true"
  prometheus.io/port: "8080"
  prometheus.io/path: "/metrics"

I packaged my changes into a Helm chart and deployed it into the Kubernetes cluster:

helm upgrade --install my-app ./operation

Once deployed, Prometheus successfully picked up the metrics endpoint, and I verified it via the Prometheus UI

Still there are connection problem with app-service module but this will be handle later week.
