### PR TITLE
Add Nginx-based local ingress proxy to Docker Compose

### DIFF
--- a/Chart/README.md
+++ b/Chart/README.md
@@ -9,11 +9,19 @@ Before using this Helm Chart, ensure the following prerequisites are met:
 1. **Kubernetes Cluster**: A **running** Kubernetes cluster (e.g., Minikube, Kind, or a cloud provider).
 2. **Helm Installed**: Helm CLI installed on your local machine. You can install Helm by following the [official guide](https://helm.sh/docs/intro/install/).
 3. **kubectl Installed**: Ensure `kubectl` is installed and configured to communicate with your Kubernetes cluster.
-4. **Prometheus Operator Installed**
+4. Start minikube for local testing:
+   ```bash
+   minikube start
+   ```
+5. **Prometheus Operator Installed**
    ```bash
    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
    helm repo update
    helm install prometheus prometheus-community/kube-prometheus-stack
+   ```
+6. Install Istio and add it to the path following instructions in [official](https://istio.io/latest/docs/setup/install/istioctl/) and run the following command to install Istio in your cluster:
+   ```bash
+   istioctl install
    ```
 
 ## Installation

--- a/Chart/values.yaml
+++ b/Chart/values.yaml
@@ -17,13 +17,13 @@ services:
         replicaCount: 3
         image:
           repository: ghcr.io/remla2025-team16/app/app-service
-          tag: latest
+          tag: v1.0.0
         containerPort: 8080
       - name: v2
         replicaCount: 3
         image:
           repository: ghcr.io/remla2025-team16/app/app-service
-          tag: latest
+          tag: v2.0.0
         containerPort: 8080
     servicePort: 8080
     containerPort: 8080
@@ -34,7 +34,7 @@ services:
     replicaCount: 1
     image:
       repository: ghcr.io/remla2025-team16/app/app-frontend
-      tag: latest
+      tag: v1.0.0
     containerPort: 3000
     servicePort: 3000
 
@@ -45,7 +45,7 @@ configMap:
     MODEL_URL: "https://github.com/remla2025-team16/model-training/releases/download/v1.0.0/sentiment-model.pkl"
 
 ingress:
-  enabled: false
+  enabled: True
   host: myapp.local
 
 serviceMonitor:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Docker Compose file defines the following services:
 
 | Service           | Build Context      | Bound Ports | Environment Variables                         |
 | ----------------- | ------------------ | ----------- | --------------------------------------------- |
-| **model-service** | `../model-service` | `5010:5010` | *(none)*                                      |
+| **model-service** | `../model-service` | `5010:5010` | `MODEL_URL=https://github.com/remla2025-team16/model-training/releases/download/v1.0.0/sentiment-model.pkl`                                     |
 | **app-service**   | `../app-service`   | `8080:8080` | `MODEL_SERVICE_URL=http://model-service:5010` |
 | **app-frontend**      | `../app-frontend`  | `3000:3000` | *(none)*                                      |
 
@@ -51,11 +51,7 @@ The Docker Compose file defines the following services:
    ```
 
 3. **Access the services**:
-
-   * Frontend UI:  [http://localhost:3000](http://localhost:3000)
-   * App Backend:  [http://localhost:8080](http://localhost:8080)
-   * Model API:    [http://localhost:5010/api/model](http://localhost:5010/api/model)
-   * Version API:  [http://localhost:5010/api/version](http://localhost:5010/api/version)
+As required, we only expose frontend to the user at [http://localhost:80](http://localhost:80)
 
 4. **Shut down** all services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,44 @@
 services:
   model-service:
     build: ../model-service
-    ports:
-      - "5010:5010"
+    expose:
+      - "5010"
     environment:
       - MODEL_URL=${MODEL_URL}
+    networks:
+      - appnet
   app-frontend:
     build:
       context: ../app/app-frontend
       dockerfile: Dockerfile
-    ports:
-      - '3000:3000'
+    expose:
+      - "3000"
+    networks:
+      - appnet
   app-service:
     build: 
       context: ../app/app-service
       dockerfile: Dockerfile
-    ports:
-      - "8080:8080"
+    expose:
+      - "8080"
     environment:
       - MODEL_SERVICE_URL=${MODEL_SERVICE_URL}
-
-  prometheus:
-    image: prom/prometheus
+    networks:
+      - appnet
+  
+  nginx:
+    image: nginx:alpine
     ports:
-      - "9090:9090"
+      - "80:80" 
+    depends_on:
+      - model-service
+      - app-service
+      - app-frontend
     volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    networks:
+      - appnet
 
-  grafana:
-    image: grafana/grafana
-    ports:
-      - "3001:3000"
-    environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
-
+networks:
+  appnet:
+    driver: bridge

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    location /model/ {
+        proxy_pass         http://model-service:5010;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+    }
+    location /api/ {
+        proxy_pass         http://app-service:8080;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+    }
+    location / {
+        proxy_pass         http://app-frontend:3000;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+    }
+}


### PR DESCRIPTION
Introduce an nginx service in docker-compose.yml to expose a single localhost:80 entrypoint and route traffic by path:
- /           → app-frontend:3000
- /api        → app-service:8080
- /model      → model-service:5010

In this way, default routing works both for docker and k8s. 